### PR TITLE
Remove init_code and global_code from mbedjs.json, and put it in BLEJS.h

### DIFF
--- a/jerryscript-mbed-ble/BLEJS.h
+++ b/jerryscript-mbed-ble/BLEJS.h
@@ -65,6 +65,7 @@ class BLEJS {
         }
 
         init_cb_function = f;
+        ble.onEventsToProcess(BLE::OnEventsToProcessCallback_t(this, &BLEJS::scheduleBleEvents));
         ble.init(this, &BLEJS::initComplete);
     }
 
@@ -143,6 +144,11 @@ class BLEJS {
         if (jerry_value_is_function(init_cb_function)) {
             jerry_call_function(init_cb_function, this_obj, NULL, 0);
         }
+    }
+
+    void scheduleBleEvents(BLE::OnEventsToProcessCallbackContext* context) {
+        BLE &ble = BLE::Instance();
+        mbed::js::EventLoop::getInstance().nativeCallback(mbed::Callback<void()>(&ble, &BLE::processEvents));
     }
 
     void connectionCallback(const Gap::ConnectionCallbackParams_t *params) {

--- a/mbedjs.json
+++ b/mbedjs.json
@@ -3,10 +3,7 @@
 		"."
 	],
 	"includes": [
-		"ble/BLE.h",
 		"jerryscript-mbed-ble/lib_ble.h"
 	],
-	"name": "ble",
-	"init_code": "BLE &ble = BLE::Instance(); ble.onEventsToProcess(scheduleBleEvents);",
-	"global_code": "static void scheduleBleEvents(BLE::OnEventsToProcessCallbackContext* context) { BLE &ble = BLE::Instance(); EventLoop::getInstance().nativeCallback(Callback<void()>(&ble, &BLE::processEvents)); }"
+	"name": "ble"
 }


### PR DESCRIPTION
Initialization code now lives in `BLEJS.h` where it belongs, instead of injecting it in `main.cpp`. Tested against https://github.com/ARMmbed/mbed-js-ble-example/commit/f291b3a178d601971068f9d65b8ef2e90411c6f8.

@matthewelse @thegecko 